### PR TITLE
set cmake minimum version at 3.15

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -2,7 +2,7 @@ project(zillizgis LANGUAGES CUDA CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CUDA_STANDARD 11)
 
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")


### PR DESCRIPTION
## What changes were proposed in this pull request?
set cmake minimum version from 3.12 to 3.15

## Why are the changes needed?
cmake 3.15 is needed to download sqlite3

## Does this PR introduce any user-facing change?
No
## How was this patch tested?
No